### PR TITLE
Make dashbuilder-bom import later than jboss-integration-platform-bom

### DIFF
--- a/kie-parent-with-dependencies/pom.xml
+++ b/kie-parent-with-dependencies/pom.xml
@@ -147,13 +147,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.dashbuilder</groupId>
-        <artifactId>dashbuilder-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.dashbuilder}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>errai-config</artifactId>
         <version>${version.org.jboss.errai}</version>
@@ -167,6 +160,14 @@
         <artifactId>jboss-integration-platform-bom</artifactId>
         <type>pom</type>
         <version>${version.org.jboss.integration-platform}</version>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.dashbuilder</groupId>
+        <artifactId>dashbuilder-bom</artifactId>
+        <type>pom</type>
+        <version>${version.org.dashbuilder}</version>
         <scope>import</scope>
       </dependency>
 


### PR DESCRIPTION
Bug 1183481 - dashbuilder-bom import should be lower priority than jboss-integration-platform-bom import.

In kie-parent-with-dependencies pom.xml, the dashbulder-bom import has the higher priority than jboss-integration-platform-bom. However dashbuilder-bom actually will introduce a dependency on jboss-integration-platform-bom.
This will cause a problem that when dashbuilder-bom is older than jboss-integration-platform-bom, then it will force droolsjbpm project use an older integration-platform-bom. And dashbuilder is outside droolsjbpm project group.
This case happened when I build 6.1.0 ER4. For some reason, dashbuilder-0.2.0.CR2 can't be rebuilt and the latest droolsjbpm still need to use old dashbuilder. 

So the request here is to make dashbuilder-bom define after jboss-integratioin-platform-bom import.