### PR TITLE
internalizing i18n taglib (so old that cannot be found on maven

### DIFF
--- a/kie-uberfire-extensions-bom/pom.xml
+++ b/kie-uberfire-extensions-bom/pom.xml
@@ -70,6 +70,18 @@
         <classifier>sources</classifier>
       </dependency>
 
+      <dependency>
+        <groupId>org.kie.uberfire</groupId>
+        <artifactId>i18n-taglib</artifactId>
+        <version>${version.org.kie.uberfire.extensions}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.uberfire</groupId>
+        <artifactId>i18n-taglib</artifactId>
+        <version>${version.org.kie.uberfire.extensions}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
central). this will help remove the .tld and .jar from the codebase
of all kie related repos.