### PR TITLE
maven-source-plugin: use -no-fork goals to avoid duplicated plugin executions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
             <execution>
               <id>jar</id>
               <goals>
-                <goal>jar</goal>
+                <goal>jar-no-fork</goal>
               </goals>
               <configuration>
                 <archive>
@@ -371,7 +371,7 @@
             <execution>
               <id>test-jar</id>
               <goals>
-                <goal>test-jar</goal>
+                <goal>test-jar-no-fork</goal>
               </goals>
               <configuration>
                 <archive>


### PR DESCRIPTION
 * the 'jar' and 'test-jar' goals invoke execution of whole
   lifecycle phase, which means all the plugins up to that
   phase are executed multiple times during the build.
   That includes for example enforcer and checkstyle plugins.
   See https://maven.apache.org/plugins/maven-source-plugin/plugin-info.html
   for more info.

 * using the -no-fork goals will make sure that only these
   goals are excuted and not the whole lifecycle again.
   The output of the build in target/ dir is the same both
   with and without this change.

@mbiarnes @ge0ffrey please take look just in case I missed something. I believe the change is safe, but its better if someone else reviews the changes before merging.