### PR TITLE
[BZ-996210] upgrade batik from 1.6-1 to 1.7

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -153,109 +153,6 @@
         - Always extract the version as a property.
         - A element's inner order is <groupId>, <artifactId>, [<type>,] [<classifier>,] <version> (following Aether proper)
       -->
-
-      <dependency>
-        <groupId>avalon-framework</groupId>
-        <artifactId>avalon-framework</artifactId>
-        <version>${version.avalon-framework}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.xmlbeans</groupId>
-        <artifactId>xmlbeans</artifactId>
-        <version>${version.org.apache.xmlbeans}</version>
-      </dependency>
-
-      <!-- TODO BZ-996210 use org.apache.xmlgraphics:batik* instead -->
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-parser</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-transcoder</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>fop</groupId>
-            <artifactId>fop</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-extension</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>xml-apis</groupId>
-            <artifactId>xmlParserAPIs</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-dom</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-xml</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-bridge</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-css</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-svg-dom</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-svggen</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-util</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-ext</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>xml-apis</groupId>
-            <artifactId>xmlParserAPIs</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-script</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-gvt</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-      <dependency>
-        <groupId>batik</groupId>
-        <artifactId>batik-awt-util</artifactId>
-        <version>${version.org.apache.xmlgraphics.batik}</version>
-      </dependency>
-
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock</artifactId>
@@ -286,6 +183,20 @@
         <groupId>javax.xml.stream</groupId>
         <artifactId>stax-api</artifactId>
         <version>${version.javax.xml.stream.stax}</version>
+      </dependency>
+
+      <!-- avalon-framework is dependency of org.apache.xmlgraphics:fop. However, the specified version 4.2.0 is
+           not available in Maven central. This overrides the version to one compatible with the fop, but also
+           available in the Maven central. -->
+      <dependency>
+        <groupId>org.apache.avalon.framework</groupId>
+        <artifactId>avalon-framework-api</artifactId>
+        <version>${version.org.apache.avalon.framework}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avalon.framework</groupId>
+        <artifactId>avalon-framework-impl</artifactId>
+        <version>${version.org.apache.avalon.framework}</version>
       </dependency>
 
       <dependency>
@@ -335,6 +246,13 @@
         <artifactId>lucene-sandbox</artifactId>
         <version>${version.org.apache.lucene}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.xmlbeans</groupId>
+        <artifactId>xmlbeans</artifactId>
+        <version>${version.org.apache.xmlbeans}</version>
+      </dependency>
+
       <!-- dependency of org.apache.lucene:lucene-sandbox -->
       <dependency>
         <groupId>jakarta-regexp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,21 +73,20 @@
     <!-- New and overwritten dependencies -->
     <!-- ################################################################################ -->
 
-    <version.avalon-framework>4.1.4</version.avalon-framework>
     <version.com.ahome-it.lienzo-core>2.0.118-RC0</version.com.ahome-it.lienzo-core>
     <version.com.github.detro>1.2.0</version.com.github.detro>
     <version.com.github.tomakehurst.wiremock>1.53</version.com.github.tomakehurst.wiremock>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
     <version.jakarta-regexp>1.4</version.jakarta-regexp>
     <version.net.jcip>1.0</version.net.jcip>
+    <version.org.apache.avalon.framework>4.3.1</version.org.apache.avalon.framework>
     <!-- Override from ip-bom, required by Selenium + PhantomJS driver -->
     <version.org.apache.commons.commons-exec>1.3</version.org.apache.commons.commons-exec>
     <!-- Override from ip-bom to get rid of Camel dependency (security related) -->
     <version.org.apache.helix>0.6.5</version.org.apache.helix>
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
-    <version.org.apache.xmlgraphics.batik>1.6-1</version.org.apache.xmlgraphics.batik>
-    <version.org.apache.xmlgraphics.commons>1.4</version.org.apache.xmlgraphics.commons>
-    <version.org.apache.xmlgraphics.fop>0.95</version.org.apache.xmlgraphics.fop>
+    <version.org.apache.xmlgraphics.commons>1.5</version.org.apache.xmlgraphics.commons>
+    <version.org.apache.xmlgraphics.fop>1.1</version.org.apache.xmlgraphics.fop>
     <version.org.assertj>1.7.1</version.org.assertj>
     <version.org.eclipse.jetty>8.1.14.v20131031</version.org.eclipse.jetty>
     <version.org.eclipse.jgit>3.7.1.201504261725-r</version.org.eclipse.jgit>


### PR DESCRIPTION
 * the artifacts in version 1.7 (and depMgmt) are
   imported from ip-bom
 * apache-fop, avalon-framework and xmlgraphics-common
   were upgraded as well to aligh the dependencies
   correctly

 * this PR needs to be merged together with the one for `jbpm-designer`