### PR TITLE
[DROOLS-799] fix update-version-all.sh script

### DIFF
--- a/script/release/update-version-all-settings.xml
+++ b/script/release/update-version-all-settings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository/>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups/>
+  <servers/>
+  <mirrors/>
+  <proxies/>
+  <profiles>
+    <profile>
+      <!-- The 'versions:update-child-modules' goal needs to resolve parent POM when updating the child modules.
+           The parent version was already updated before calling the update-child-modules, so the (usually)
+           SNAPSHOT parent POM needs to be downloaded from remote repo (JBoss Nexus). -->
+      <id>jboss-public-repo</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repo</id>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-public-repo</id>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>jboss-public-repo</activeProfile>
+  </activeProfiles>
+
+</settings>


### PR DESCRIPTION
 * script now automatically updates all the required
   versions in order to successfully build all the repos

 * removed the call to ant script in buid-distribution
   at the end; using simple sed string replacements instead

 * the current (old) version param is not used, so no need
   to pass it in

@mbiarnes please take a look and let me know if you have any questions. I tested the script locally, but would be great if you could test it as well to be sure everything works as expected.