### PR TITLE
[BZ-1217651] upgrade Helix from 0.6.2-incubating to 0.6.5

### DIFF
--- a/kie-parent-with-dependencies/pom.xml
+++ b/kie-parent-with-dependencies/pom.xml
@@ -39,6 +39,8 @@
     <version.net.jcip>1.0</version.net.jcip>
     <!-- Override from ip-bom, required by Selenium + PhantomJS driver -->
     <version.org.apache.commons.commons-exec>1.3</version.org.apache.commons.commons-exec>
+    <!-- Override from ip-bom to get rid of Camel dependency (security related) -->
+    <version.org.apache.helix>0.6.5</version.org.apache.helix>
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
     <version.org.apache.xmlgraphics.batik>1.6-1</version.org.apache.xmlgraphics.batik>
     <version.org.apache.xmlgraphics.commons>1.4</version.org.apache.xmlgraphics.commons>
@@ -390,6 +392,12 @@
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-ws-addr</artifactId>
         <version>${version.org.apache.cxf}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.helix</groupId>
+        <artifactId>helix-core</artifactId>
+        <version>${version.org.apache.helix}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
 * this version removes the dependency on Camel
