### PR TITLE
Add Issue Keeper dependency

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -289,6 +289,12 @@
       </dependency>
 
       <dependency>
+        <groupId>link.bek.tools</groupId>
+        <artifactId>issue-keeper-junit</artifactId>
+        <version>${version.link.bek.tools.issue-keeper-junit}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-bindings-xml</artifactId>
         <version>${version.org.apache.cxf}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <version.com.github.tomakehurst.wiremock>1.53</version.com.github.tomakehurst.wiremock>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
     <version.jakarta-regexp>1.4</version.jakarta-regexp>
+    <version.link.bek.tools.issue-keeper-junit>4.11.1</version.link.bek.tools.issue-keeper-junit>
     <version.net.jcip>1.0</version.net.jcip>
     <!-- Override from ip-bom, required by Selenium + PhantomJS driver -->
     <version.org.apache.commons.commons-exec>1.3</version.org.apache.commons.commons-exec>


### PR DESCRIPTION
Issue Keeper will allow us to connect tests with BZs or JIRAs using simple annotations. The test with such annotation is not run unless the related issue is resolved.

This is mostly used in jBPM engine tests which are being moved from QE test suite to jBPM repository and depend on the states of the related BZs.