### PR TITLE
Enable code coverage analysis with JaCoCo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,9 @@
     <latestReleasedVersionFromThisBranch>notYetReleased</latestReleasedVersionFromThisBranch>
     <!-- Version of the KIE Workbench application. Shown for example in About dialog. Will be usually overriden by productisation. -->
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
+
+    <!-- Set default argLine value to empty to prevent surefire failure when jacoco is disabled -->
+    <surefire.argLine></surefire.argLine>
   </properties>
 
   <repositories>
@@ -417,7 +420,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.18.1</version>
           <configuration>
             <includes>
               <include>**/*Test.java</include>
@@ -425,7 +428,8 @@
             <excludes>
               <exclude>**/*IntegrationTest.java</exclude>
             </excludes>
-            <argLine>-Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8</argLine>
+            <!-- Append surefire.argLine property populated by JaCoCo plugin -->
+            <argLine>-Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8 @{surefire.argLine}</argLine>
             <systemProperties>
               <property>
                 <name>apple.awt.UIElement</name>
@@ -442,7 +446,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.18.1</version>
           <executions>
             <execution>
               <goals>
@@ -457,6 +461,51 @@
             </includes>
             <argLine>-Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8</argLine>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.7.5.201505241946</version>
+          <executions>
+            <execution>
+              <id>default-prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+              <configuration>
+                <propertyName>surefire.argLine</propertyName>
+              </configuration>
+            </execution>
+            <execution>
+              <id>default-report</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <!-- Do not fail the build if rules are not met -->
+                <haltOnFailure>false</haltOnFailure>
+                <rules>
+                  <rule>
+                    <element>BUNDLE</element>
+                    <limits>
+                      <limit>
+                        <counter>LINE</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>0.9</minimum>
+                      </limit>
+                    </limits>
+                  </rule>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <!-- Packaging -->
         <plugin>
@@ -964,6 +1013,23 @@
   </reporting>
 
   <profiles>
+    <profile>
+      <!-- Code coverage disabled by default (use -Dcode-coverage to activate it) -->
+      <id>code-coverage</id>
+      <activation>
+        <property>
+          <name>code-coverage</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>fullProfile</id>
       <activation>


### PR DESCRIPTION
Adding JaCoCo configuration to `kie-parent-metadata` makes code coverage analysis ready to use in any droolsjbpm project. I find this potentially useful for both QA engineers and developers who want to quickly find code pieces lacking test coverage.

I have introduced a simple rule that requires 90% line coverage. The plugin wil print a warning if the requirement is not met. This can be changed or the check execution can be removed completely. More interesting is the HTML report of code coverage that is generated after running

```shell
mvn clean verify -Djacoco
```

The reports can be found in `target/site/jacoco/index.html` in any module that executed some tests.

The test execution analysis and subsequent report generation may add some 10-50% to build time (very roughly) so I put JaCoCo plugin into a profile that is not active by default. It can be activated with `-Djacoco`.

Surefire upgraded so that JaCoCo agent path passed in `argLine` can be
combined with memory options for test execution ([SUREFIRE-1047](https://issues.apache.org/jira/browse/SUREFIRE-1047) fixed in 2.17).