### PR TITLE
Update errai-cdi10 version to 3.0.5.Final to match support version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <!-- Dependency of maven 3.2.2  -->
     <version.org.jboss.errai>3.2.0-SNAPSHOT</version.org.jboss.errai>
     <!-- Version of Errai compatible with CDI 1.0. Few artifacts in this version are used for CDI 1.0 compatible WAR distributions. -->
-    <version.org.jboss.errai.cdi10-compatible>3.0.4.Final</version.org.jboss.errai.cdi10-compatible>
+    <version.org.jboss.errai.cdi10-compatible>3.0.6.Final</version.org.jboss.errai.cdi10-compatible>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
     <version.com.unboundid>2.3.6</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>


### PR DESCRIPTION
The latest Errai support version on 3.0.x is 3.0.5.Final-redhat-1. So let's update to 3.0.5.Final.
I hope that's ok.