### PR TITLE
removed javax.security.jacc

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -292,12 +292,6 @@
         <version>${version.com.unboundid}</version>
       </dependency>
 
-      <dependency>
-        <groupId>javax.security.jacc</groupId>
-        <artifactId>javax.security.jacc-api</artifactId>
-        <version>${version.javax.security.jacc}</version>
-      </dependency>
-
       <!-- temporary because it was removed/rename in jboss-ip-bom and it is needed by droolsjbpm-knowledge/kie-api/pom.xml -->
       <dependency>
         <groupId>javax.xml.stream</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <!-- temporary, should be moved to jboss-ip-bom -->
     <version.org.gwtbootstrap3>0.9.1</version.org.gwtbootstrap3>
-    <version.javax.security.jacc>1.4</version.javax.security.jacc>
     <!-- temporary because it was removed/rename in jboss-ip-bom and it is needed by droolsjbpm-knowledge/kie-api/pom.xml -->
     <version.javax.xml.stream.stax>1.0-2</version.javax.xml.stream.stax>
     <!-- overrides <version.org.jboss.as> 7.4.0.Final used in jboss-ip-bom 6.0.0.CR13 -->


### PR DESCRIPTION
this PR only can be merged after https://github.com/droolsjbpm/droolsjbpm-integration/pull/196 in droolsjbpm-integration was merged!
When merged this it has to be cherry-picked to 6.3.x branch.
