### PR TITLE
Use mockito-core instead of mockito-all (which is an uberjar)

### DIFF
--- a/kie-parent-with-dependencies/pom.xml
+++ b/kie-parent-with-dependencies/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
@mbiarnes, @ge0ffrey do you remember if there was a reason to use `mockito-all`? It is an uberjar and those should not be used at all. `mockito-core` properly specifies the other dependencies, so I believe this change should be transparent.