### PR TITLE
upgraded to jboss-ip-bom 6.0.0.CR29

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -280,14 +280,6 @@
         <version>${version.com.google.android}</version>
       </dependency>
 
-      <!-- Can be removed once https://github.com/jboss-integration/jboss-integration-platform-bom/pull/213 is merged
-           and next ip-bom released. -->
-      <dependency>
-        <groupId>com.sun.codemodel</groupId>
-        <artifactId>codemodel</artifactId>
-        <version>${version.com.sun.codemodel}</version>
-      </dependency>
-
       <dependency>
         <groupId>de.benediktmeurer.gwt-slf4j</groupId>
         <artifactId>gwt-slf4j</artifactId>
@@ -415,6 +407,7 @@
           </exclusion>
         </exclusions>
       </dependency>
+
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>xmlgraphics-commons</artifactId>
@@ -438,13 +431,6 @@
         <groupId>org.eclipse.jdt.core.compiler</groupId>
         <artifactId>ecj</artifactId>
         <version>${version.org.eclipse.jdt.core.compiler}</version>
-      </dependency>
-
-      <!-- Jolokia  -->
-      <dependency>
-        <groupId>org.jolokia</groupId>
-        <artifactId>jolokia-client-java</artifactId>
-        <version>${version.org.jolokia}</version>
       </dependency>
 
       <!-- Dependency of maven 3.2.2  -->
@@ -596,12 +582,6 @@
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-user</artifactId>
         <version>${version.com.google.gwt}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>net.jcip</groupId>
-        <artifactId>jcip-annotations</artifactId>
-        <version>${version.net.jcip}</version>
       </dependency>
 
       <dependency>
@@ -847,12 +827,6 @@
         <groupId>org.jboss.xnio</groupId>
         <artifactId>xnio-nio</artifactId>
         <version>${version.org.jboss.xnio}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jgroups</groupId>
-        <artifactId>jgroups</artifactId>
-        <version>${version.org.jgroups}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with property <version.org.jboss.integration-platform> -->
-    <version>6.0.0.CR28</version>
+    <version>6.0.0.CR29</version>
   </parent>
 
   <groupId>org.kie</groupId>
@@ -68,7 +68,7 @@
 
     <!-- External dependency versions bom -->
     <!-- Keep in sync with <parent>'s <version> -->
-    <version.org.jboss.integration-platform>6.0.0.CR28</version.org.jboss.integration-platform>
+    <version.org.jboss.integration-platform>6.0.0.CR29</version.org.jboss.integration-platform>
     <!-- ################################################################################ -->
     <!-- New and overwritten dependencies -->
     <!-- ################################################################################ -->
@@ -79,11 +79,9 @@
     <version.com.github.detro>1.2.0</version.com.github.detro>
     <version.com.github.tomakehurst.wiremock>1.53</version.com.github.tomakehurst.wiremock>
     <version.com.google.android>4.1.1.4</version.com.google.android>
-    <version.com.sun.codemodel>2.6</version.com.sun.codemodel>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
     <version.jakarta-regexp>1.4</version.jakarta-regexp>
     <version.link.bek.tools.issue-keeper-junit>4.11.1</version.link.bek.tools.issue-keeper-junit>
-    <version.net.jcip>1.0</version.net.jcip>
     <!-- this version will overwrite the jboss-ip-bom version 3.6.2. the jboss-ip-bom version has to remain as the 4.0.0 breaks ModeShape nor is Lucene 4.0.0 part of the latest EAP-->
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
     <version.org.apache.xmlgraphics.batik>1.6-1</version.org.apache.xmlgraphics.batik>
@@ -92,9 +90,6 @@
     <version.org.assertj>1.7.1</version.org.assertj>
     <!-- overwrites the version of org.jboss.xnio defined in jboss-ip-bom because needed by WildFly -->
     <version.org.jboss.xnio>3.2.0.Final</version.org.jboss.xnio>
-    <!-- overwrites the version of jroups in ip-bom because the needed artifacts don't exit it the ip-bom version -->
-    <version.org.jgroups>3.2.13.Final</version.org.jgroups>
-    <version.org.jolokia>1.2.2</version.org.jolokia>
     <version.org.mortbay.jetty>6.1.25</version.org.mortbay.jetty>
     <version.org.mortbay.jetty.runner>8.1.7.v20120910</version.org.mortbay.jetty.runner>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>


### PR DESCRIPTION
@Petr: here is the upgrade to jboss-ip-bom 6.0.0.CR29.
I run the build and executed the tests AND took your branch ip-bom-cr29 with some fixes for the tests.
Finally there failed three tests (which I thik it is quit normal): http://kie-releases.lab.eng.brq.redhat.com/kie-artifacts/jboss-ip-bom-6.0.0.CR29/failedUnitTests/21.10.2015-22.48/