### PR TITLE
Add common GWT properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,13 @@
     <maven.min.version>3.2.3</maven.min.version>
     <!-- exposed additional params for javadoc, such as Xlint -->
     <javadoc.additional.params/>
+    <!-- Important: this is one and only place where the supported user agents (browsers) are configured.
+         All webapps/showcases must use this property in their *.gwt.xml files.
+         We only need to support IE11+, but there is no ie11 permutation. IE11 will use the Firefox one (gecko1_8) -->
+    <gwt.user.agent.all>gecko1_8,safari</gwt.user.agent.all>
+    <!-- Number of GWT compiler worker processes. Defined as property so that it can be easily overridden from cmd line.
+         Default value is 1 to enable building on older machines as well (minimum is still about 4GiB of RAM memory). -->
+    <gwt.compiler.localWorkers>1</gwt.compiler.localWorkers>
     <!-- enabling the next line will do that the build will not break when an illegal transitive dependency is found,
          the default is: the next line commented -->
     <!-- <illegaltransitivereportonly>true</illegaltransitivereportonly> -->
@@ -858,6 +865,7 @@
           <artifactId>gwt-maven-plugin</artifactId>
           <version>${version.com.google.gwt}</version>
           <configuration>
+            <localWorkers>${gwt.compiler.localWorkers}</localWorkers>
             <strict>true</strict>
           </configuration>
         </plugin>


### PR DESCRIPTION
@csadilek, @porcelli, @manstis this is first of many PRs related to GWT config. I would like to declare the config at one place (kie-parent-metadata) and then use it in other repos. This should make certain configuration fixes/updates much easier. 