### PR TITLE
BZ-1274685 - New Repository dialog validation broken when Managed Repository is checked

### DIFF
--- a/guvnor-bom/pom.xml
+++ b/guvnor-bom/pom.xml
@@ -69,6 +69,12 @@
       </dependency>
       <dependency>
         <groupId>org.guvnor</groupId>
+        <artifactId>guvnor-structure-client</artifactId>
+        <version>${version.org.guvnor}</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.guvnor</groupId>
         <artifactId>guvnor-project-api</artifactId>
         <version>${version.org.guvnor}</version>
       </dependency>


### PR DESCRIPTION
Simple modification to allow dependency setting to tests stuff.
