### PR TITLE
Remove dependencies already prenset in IP BOM

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -414,16 +414,11 @@
         <version>${version.org.apache.xmlgraphics.commons}</version>
       </dependency>
 
+      <!-- Can be removed once ip-bom with https://github.com/jboss-integration/jboss-integration-platform-bom/pull/248 is used -->
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.org.assertj}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse</groupId>
-        <artifactId>org.eclipse.bpmn2</artifactId>
-        <version>${version.org.eclipse.bpmn2}</version>
       </dependency>
 
       <!-- needed by jbpm-form-modeler -->
@@ -856,28 +851,12 @@
         <version>${version.org.gwtbootstrap3}</version>
       </dependency>
 
-      <!-- Selenium dependencies -->
-      <!-- There is no official Selenium BOM, so we are using one coming from Arquillian
-           (contains only pure Selenium deps, no ARQ deps are leaking from this BOM) -->
-      <dependency>
-        <groupId>org.jboss.arquillian.selenium</groupId>
-        <artifactId>selenium-bom</artifactId>
-        <version>${version.org.seleniumhq.selenium}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <dependency>
         <groupId>com.github.detro</groupId>
         <artifactId>phantomjsdriver</artifactId>
         <version>${version.com.github.detro}</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.mvel</groupId>
-        <artifactId>mvel2</artifactId>
-        <version>${version.org.mvel}</version>
-      </dependency>
     </dependencies>
 
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
     <!-- ################################################################################ -->
     <!-- New and overwritten dependencies -->
     <!-- ################################################################################ -->
-    <version.org.eclipse.bpmn2>0.7.6-jboss</version.org.eclipse.bpmn2>
     <version.avalon-framework>4.1.4</version.avalon-framework>
     <version.com.ahome-it.lienzo-core>2.0.118-RC0</version.com.ahome-it.lienzo-core>
     <version.com.android-dx>1.10</version.com.android-dx>
@@ -117,7 +116,6 @@
     <version.org.jboss.byteman>3.0.1</version.org.jboss.byteman>
     <version.org.roboguice>3.0.1</version.org.roboguice>
     <version.org.robolectric>2.4</version.org.robolectric>
-    <version.org.seleniumhq.selenium>2.46.0</version.org.seleniumhq.selenium>
     <version.org.simpleframework>6.0.1</version.org.simpleframework>
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->


### PR DESCRIPTION
 * all those deps are already in ip-bom:6.0.0.CR29
   with exactly the same versions

@mbiarnes please take a look.