### PR TITLE
git-clone-others.sh: support URLs not ending with .git

### DIFF
--- a/script/git-clone-others.sh
+++ b/script/git-clone-others.sh
@@ -29,7 +29,7 @@ startDateTime=`date +%s`
 # Anonymous users on blessed gitUrlPrefix="git://github.com/droolsjbpm/"
 cd "${scriptDir}"
 droolsjbpmGitUrlPrefix=`git remote -v | grep --regex "^origin.*(fetch)$"`
-droolsjbpmGitUrlPrefix=`echo ${droolsjbpmGitUrlPrefix} | sed 's/^origin\s*//g' | sed 's/droolsjbpm\-build\-bootstrap\.git.*//g'`
+droolsjbpmGitUrlPrefix=`echo ${droolsjbpmGitUrlPrefix} | sed 's/^origin\s*//g' | sed 's/droolsjbpm\-build\-bootstrap.*//g'`
 
 cd "$droolsjbpmOrganizationDir"
 


### PR DESCRIPTION
 * when cloning from github, one can use both github.com/org/repo
   and github.com/org/repo.git. This change add supports for the
   former (without .git suffix) URL

@mbiarnes this is a trivial change, but please double check anyway.