### PR TITLE
maven-bundle-plugin: disable OBR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,6 +394,7 @@
               <_snapshot>${osgi.snapshot.qualifier}</_snapshot>
               <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${osgi.snapshot.qualifier}</Bundle-Version>
             </instructions>
+            <obrRepository>NONE</obrRepository>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
 * updates to local OBR (OSGi Bundle Repository) are not
   necessary and they only prolong the build if the repository
   (by default ~/.m2/repository/repository.xml) is large

@mariofusco please take a look as this is related to OSGi