### PR TITLE
BZ 1255837 / 1255834 - CVE-2015-0250 - update to batik 1.6.1-1

### DIFF
--- a/kie-parent-with-dependencies/pom.xml
+++ b/kie-parent-with-dependencies/pom.xml
@@ -39,7 +39,7 @@
     <!-- Override from ip-bom to get rid of Camel dependency (security related) -->
     <version.org.apache.helix>0.6.5</version.org.apache.helix>
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
-    <version.org.apache.xmlgraphics.batik>1.6-1</version.org.apache.xmlgraphics.batik>
+    <version.org.apache.xmlgraphics.batik>1.6.1-1</version.org.apache.xmlgraphics.batik>
     <version.org.apache.xmlgraphics.commons>1.4</version.org.apache.xmlgraphics.commons>
     <version.org.apache.xmlgraphics.fop>0.95</version.org.apache.xmlgraphics.fop>
     <version.org.eclipse.jetty>8.1.14.v20131031</version.org.eclipse.jetty>


### PR DESCRIPTION
6.2.x PR - reference BZs 

https://bugzilla.redhat.com/show_bug.cgi?id=1255837
https://bugzilla.redhat.com/show_bug.cgi?id=1255834