### PR TITLE
Update copyright holder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ Configuring Eclipse
 
         ```
         /*
-         * Copyright 2015 JBoss Inc
+         * Copyright 2015 Red Hat, Inc. and/or its affiliates.
          *
          * Licensed under the Apache License, Version 2.0 (the "License");
          * you may not use this file except in compliance with the License.
@@ -1069,12 +1069,12 @@ Configuring IntelliJ
 
         * Click button *+* to add a *Copyright profile*
 
-        * Textfield *name*: `JBoss Inc`
+        * Textfield *name*: `Red Hat, Inc. and/or its affiliates`
 
         * Textarea with content:
 
             ```
-            Copyright $today.year JBoss Inc
+            Copyright $today.year Red Hat, Inc. and/or its affiliates.
 
             Licensed under the Apache License, Version 2.0 (the "License");
             you may not use this file except in compliance with the License.
@@ -1095,7 +1095,7 @@ Configuring IntelliJ
 
     * Click tree item *Copyright*
 
-        * Combobox *Default project copyright*: `JBoss Inc`
+        * Combobox *Default project copyright*: `Red Hat, Inc. and/or its affiliates`
 
 Extra IntelliJ plugins
 ----------------------

--- a/ide-configuration/LICENSE-ASL-2.0-HEADER.txt
+++ b/ide-configuration/LICENSE-ASL-2.0-HEADER.txt
@@ -1,4 +1,4 @@
-Copyright ${year} JBoss Inc
+Copyright ${year} Red Hat, Inc. and/or its affiliates.
  
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
JBoss Inc. has not actually existed since 2006 :)
Here I suggest updating the copyright notices in this repository to refer to 'Red Hat, Inc. and/or its affiliates', if only because this is providing guidance to droolsjbpm projects on how to handle copyright notices.

Note that a Red Hat-specific copyright notice is not necessarily the best choice. Another possibility which you may wish to consider would be to refer generally to contributors to $projectname, e.g. 'Copyright $year Drools Authors'. 