### PR TITLE
Upgrade Cargo plugin version to 1.4.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven2-plugin</artifactId>
-          <version>1.4.14</version>
+          <version>1.4.18</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Cargo is used just for integration tests, raising of version allows to create WebSphere standalone profiles.