### PR TITLE
Use released version of Guava: 19.0.0.jbossorg-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.com.google.gwt>2.8.0-beta1</version.com.google.gwt>
-    <version.com.google.guava>20.0-SNAPSHOT</version.com.google.guava>
+    <version.com.google.guava>19.0.0.jbossorg-1</version.com.google.guava>
     <!-- this version will overwrite jboss-ip-version 3.1.2. The version in jboss-ip-bom couldn't be upgraded as this version needs GWT 2.7.0 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>


### PR DESCRIPTION
 * this is a custom Guava build taken from current master.
   It is called 19* because it really is just 19 + bunch
   of fixes. Calling it 20* would be more confusing.