### PR TITLE
Move optaplanner-wb to just below drools-wb

### DIFF
--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -10,10 +10,10 @@ guvnor
 kie-wb-common
 jbpm-form-modeler
 drools-wb
+optaplanner-wb
 jbpm-designer
 jbpm-console-ng
 dashboard-builder
-optaplanner-wb
 jbpm-dashboard
 kie-docs
 kie-wb-distributions


### PR DESCRIPTION
because jbpm human tasks might some day use optaplanner which uses drools