### PR TITLE
[6.4.x] Upgrade Errai from 3.2.2-SNAPSHOT to 3.2.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <version.org.jboss.xnio>3.2.0.Final</version.org.jboss.xnio>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
     <version.org.drools.guvnor-api>5.6.0.Final</version.org.drools.guvnor-api>
-    <version.org.jboss.errai>3.2.2-SNAPSHOT</version.org.jboss.errai>
+    <version.org.jboss.errai>3.2.3-SNAPSHOT</version.org.jboss.errai>
     <!-- Version of Errai compatible with CDI 1.0. Few artifacts in this version are used for CDI 1.0 compatible WAR distributions. -->
     <version.org.jboss.errai.cdi10-compatible>3.0.6.Final</version.org.jboss.errai.cdi10-compatible>
     <version.org.mortbay.jetty.runner>8.1.7.v20120910</version.org.mortbay.jetty.runner>


### PR DESCRIPTION
@csadilek, @mbarkley maybe we should just upgrade to 3.2.2.Final? In any case, we should not depend on 3.2.2-SNAPSHOT anymore.