### PR TITLE
Upgrade revapi-java from 0.6.0 to 0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
             <dependency>
               <groupId>org.revapi</groupId>
               <artifactId>revapi-java</artifactId>
-              <version>0.6.0</version>
+              <version>0.6.1</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
 * 0.6.1 supports JDK 9 EA builds
   (just the runtime itself, not jigsaw
   or other Java 9 features)