### PR TITLE
[GUVNOR-2410] disable UF git/ssh daemons for unit testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,12 +417,12 @@
               <exclude>**/*IntegrationTest.java</exclude>
             </excludes>
             <argLine>-Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8</argLine>
-            <systemProperties>
-              <property>
-                <name>apple.awt.UIElement</name>
-                <value>true</value>
-              </property>
-            </systemProperties>
+            <systemPropertyVariables>
+              <apple.awt.UIElement>true</apple.awt.UIElement>
+              <org.uberfire.nio.git.daemon.enabled>false</org.uberfire.nio.git.daemon.enabled>
+              <org.uberfire.nio.git.ssh.enabled>false</org.uberfire.nio.git.ssh.enabled>
+              <org.uberfire.sys.repo.monitor.disabled>true</org.uberfire.sys.repo.monitor.disabled>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Backport of #178. Touches only tests and makes them more reliable in case of parallel build.