### PR TITLE
Use canonical URLs for Maven deploy repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
     <latestReleasedVersionFromThisBranch>notYetReleased</latestReleasedVersionFromThisBranch>
     <!-- Version of the KIE Workbench application. Shown for example in About dialog. Will be usually overridden by productisation. -->
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
+
+    <!-- Using origin-repository.jboss.org as that is the canonical URL for deployment. repository.jboss.org is just a proxy
+         which should delegate the calls to origin-repository.jboss.org, but that is often buggy. Using the canonical URL
+         directly should help to avoid some of the issues with deploying artifacts. -->
+    <jboss.releases.repo.url>https://origin-repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+    <jboss.snapshots.repo.url>https://origin-repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This fixes/workarounds the current issues with SNAPSHOT deploys.