### PR TITLE
- avoiding JNDI errors when testing with uberfire code

### DIFF
--- a/kie-third-party-bom/pom.xml
+++ b/kie-third-party-bom/pom.xml
@@ -742,6 +742,12 @@
         <version>${version.com.github.detro}</version>
       </dependency>
 
+      <dependency>
+        <groupId>simple-jndi</groupId>
+        <artifactId>simple-jndi</artifactId>
+        <version>${version.simple-jndi}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,8 @@
     <version.org.geronimo.atinject>1.0</version.org.geronimo.atinject>
     <!-- since ironjacamar was removed from the ip-ip-bom but is still needed from dashboard-builder all dependencies are placed here -->
     <version.org.jboss.ironjacamar>1.0.31.Final</version.org.jboss.ironjacamar>
+    <!-- simple-jndi is a small library that helps us avoid JNDI error messages during testing -->
+    <version.simple-jndi>0.11.4.1</version.simple-jndi>
     <!-- In community builds productized is false, in product builds it's true to enable branding changes -->
     <org.kie.productized>false</org.kie.productized>
 


### PR DESCRIPTION
[This use](https://github.com/uberfire/uberfire/blob/master/uberfire-commons/src/main/java/org/uberfire/commons/async/SimpleAsyncExecutorService.java#L75) of the `InitialContext` is causing errors in my tests, and `simple-jndi` (scope:test) fixes them. :) 

See for more info: http://fandry.blogspot.nl/2011/03/junit-based-integration-testing-with.html