### PR TITLE
[DROOLS-1136] remove references to droolsjbpm-build-distribution repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Running the build
     ```shell
     $ cd ~/projects/droolsjbpm
     $ ls
-    drools  droolsjbpm-build-bootstrap  droolsjbpm-build-distribution  droolsjbpm-integration  droolsjbpm-knowledge  droolsjbpm-tools  optaplanner  guvnor
+    drools  droolsjbpm-build-bootstrap droolsjbpm-integration  droolsjbpm-knowledge  droolsjbpm-tools  optaplanner  guvnor
     $ cd guvnor
     $ ls
     ...  guvnor-repository  guvnor-webapp-drools  pom.xml

--- a/RELEASE-README.md
+++ b/RELEASE-README.md
@@ -151,7 +151,7 @@ One week in advance:
 
     * Do a sanity check of the artifacts by running each runExamples.sh from the zips.
 
-        * Go to `droolsjbpm-build-distribution/droolsjbpm-uber-distribution/target/*/download_jboss_org`:
+        * Go to `kie-wb-distributions/droolsjbpm-uber-distribution/target/*/download_jboss_org`:
 
             * Unzip the zips to a temporary directory.
 
@@ -590,7 +590,7 @@ If everything is perfect (compiles, Jenkins is all blue, sanity checks succeed a
 
 * Upload the zips, documentation and javadocs to filemgmt and update the website.
 
-    * Go to `droolsjbpm-build-distribution/droolsjbpm-uber-distribution/target`.
+    * Go to `kie-wb-distributions/droolsjbpm-uber-distribution/target`.
 
     * To get access to `filemgmt.jboss.org`, see preparation above.
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
     <version.org.guvnor>${version.org.drools}</version.org.guvnor>
     <version.org.kie.uberfire.extensions>${version.org.drools}</version.org.kie.uberfire.extensions>
     <version.org.drools.droolsjbpm-tools>${version.org.drools}</version.org.drools.droolsjbpm-tools>
-    <version.org.drools.droolsjbpm-build-distribution>${version.org.drools}</version.org.drools.droolsjbpm-build-distribution>
     <version.org.jbpm.jbpm-designer>${version.org.jbpm}</version.org.jbpm.jbpm-designer>
     <version.org.jbpm.jbpm-form-modeler>${version.org.jbpm}</version.org.jbpm.jbpm-form-modeler>
     <version.org.jbpm.jbpm-console-ng>${version.org.jbpm}</version.org.jbpm.jbpm-console-ng>

--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -17,5 +17,4 @@ dashboard-builder
 jbpm-dashboard
 kie-docs
 kie-wb-distributions
-droolsjbpm-build-distribution
 kie-eap-modules


### PR DESCRIPTION
 * content of droolsjbpm-build-distribution was merged
   into kie-wb-distributions. Having a separate
   repository for just one module is an overkill
   and only adds maintenance burden