### PR TITLE
maven-failsafe-plugin: allow test classes to end also with "IT"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
           <configuration>
             <includes>
               <include>**/*IntegrationTest.java</include>
+              <include>**/*IT.java</include>
             </includes>
             <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
           </configuration>


### PR DESCRIPTION
 * IntegrationTest is just too long. IT is well established shortcut for
   integration tests so makes sense to support it