### PR TITLE
Separated Cargo plugin version to property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <version.org.apache.xmlgraphics.commons>1.4</version.org.apache.xmlgraphics.commons>
     <version.org.apache.xmlgraphics.fop>0.95</version.org.apache.xmlgraphics.fop>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
+    <version.org.codehaus.cargo>1.4.19</version.org.codehaus.cargo>
     <version.org.jboss.arquillian.extension.drone>2.0.0.Final</version.org.jboss.arquillian.extension.drone>
     <version.org.jboss.arquillian.graphene>2.1.0.CR1</version.org.jboss.arquillian.graphene>
     <version.org.drools.guvnor-api>5.6.0.Final</version.org.drools.guvnor-api>
@@ -418,7 +419,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven2-plugin</artifactId>
-          <version>1.4.19</version>
+          <version>${version.org.codehaus.cargo}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Allows us to share version number between Cargo plugin and Cargo dependencies if they are used separately.