### PR TITLE
Remove dashboard-builder and jbpm-dashbuilder from the repository-list.txt

### DIFF
--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -13,8 +13,6 @@ drools-wb
 optaplanner-wb
 jbpm-designer
 jbpm-console-ng
-dashboard-builder
-jbpm-dashboard
 kie-docs
 kie-wb-distributions
 kie-eap-modules


### PR DESCRIPTION
 * these repos will never be released as part of 7.x series,
   so there is no need to keep building them