### PR TITLE
Upgrade org.mvel from 2.2.8.Final to 2.3.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,8 @@
     <version.org.jboss.errai>4.0.0-SNAPSHOT</version.org.jboss.errai>
     <!-- Version of Errai compatible with CDI 1.0. Few artifacts in this version are used for CDI 1.0 compatible WAR distributions. -->
     <version.org.jboss.errai.cdi10-compatible>3.0.6.Final</version.org.jboss.errai.cdi10-compatible>
+    <!-- MVEL 2.3.0.Final override can be removed once we use IP BOM which includes https://github.com/jboss-integration/jboss-integration-platform-bom/pull/320 -->
+    <version.org.mvel>2.3.0.Final</version.org.mvel>
     <version.org.mortbay.jetty.runner>8.1.7.v20120910</version.org.mortbay.jetty.runner>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
     <version.com.unboundid>2.3.6</version.com.unboundid>


### PR DESCRIPTION
 * 2.3.0.Final brings initial Java 9 support
   (no modules support, just works on the EA build 120)