### PR TITLE
ERRAI-963: Remove errai-js.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1468,17 +1468,6 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.errai</groupId>
-        <artifactId>errai-js</artifactId>
-        <version>${version.org.jboss.errai}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.errai</groupId>
         <artifactId>errai-cdi-server</artifactId>
         <version>${version.org.jboss.errai}</version>
         <exclusions>


### PR DESCRIPTION
[This issue](https://issues.jboss.org/browse/ERRAI-963) describes why errai-js was being removed. The dependency management removed in this PR appears to be the only reference to errai-js in the droolsjbpm organization.