### PR TITLE
Add resteasy-client dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1649,6 +1649,12 @@
         <version>${version.simple-jndi}</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-client</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
I have added resteasy-client dependency which is needed for the REST client in kie-wb-distributions/kie-wb-tests/kie-wb-tests-rest. I will send a pull request to jboss-integration-platform-bom but in the meantime we need to have it at least here.