### PR TITLE
Revert "upgraded jboss-ip-bom to 6.0.7.Final (#225)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with property <version.org.jboss.integration-platform> -->
-    <version>6.0.7.Final</version>
+    <version>6.0.6.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>
@@ -68,7 +68,7 @@
 
     <!-- External dependency versions bom -->
     <!-- Keep in sync with <parent>'s <version> -->
-    <version.org.jboss.integration-platform>6.0.7.Final</version.org.jboss.integration-platform>
+    <version.org.jboss.integration-platform>6.0.6.Final</version.org.jboss.integration-platform>
     <!-- ################################################################################ -->
     <!-- New and overwritten dependencies -->
     <!-- ################################################################################ -->


### PR DESCRIPTION
This reverts commit 21ce25c7e67755a71824aae2d9f58215bda29d97.
As ip-bom 6.0.7.Final contains an upgrade to <version.com.thoughtworks.xstream>1.4.9 and this 
contains Java 8 (*non*-backwards compatibile) code, which causes Webpshere to prevent the BPMS
webservice from deploying we have to revert this.