### PR TITLE
DROOLS-355 - Migrating DroolsJaxbHelperImpl from XJC/CodeModel code to a different framework

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -98,13 +98,6 @@
         <version>${version.org.jboss.errai}</version>
         <scope>import</scope>
       </dependency>
-
-      <dependency>
-        <groupId>org.asciidoctor</groupId>
-        <artifactId>asciidoctorj-pdf</artifactId>
-        <version>${version.org.asciidoctor.pdf}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <version.org.robolectric>2.4</version.org.robolectric>
     <version.org.jboss.arquillian.selenium>2.53.0</version.org.jboss.arquillian.selenium>
     <version.org.simpleframework>6.0.1</version.org.simpleframework>
-    <!-- WildFly version used together with  the GWT's Super Dev Mode -->
+    <!-- WildFly version used together with the GWT's Super Dev Mode -->
     <version.org.wildfly.gwt.sdm>10.0.0.Final</version.org.wildfly.gwt.sdm>
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
@@ -126,7 +126,7 @@
     <version.simple-jndi>0.11.4.1</version.simple-jndi>
     <version.org.asciidoctor.pdf>1.5.0-alpha.11</version.org.asciidoctor.pdf>
 
-    <!-- Required for Errai Dynamic Bean validation  -->
+    <!-- Required for Errai Dynamic Bean validation -->
     <version.org.hibernate.hibernate-validator>4.1.0.Final</version.org.hibernate.hibernate-validator>
     <version.javax.validation.validation-api>1.0.0.GA</version.javax.validation.validation-api>
 
@@ -165,12 +165,14 @@
     <latestReleasedVersionFromThisBranch>notYetReleased</latestReleasedVersionFromThisBranch>
     <!-- Version of the KIE Workbench application. Shown for example in About dialog. Will be usually overridden by productisation. -->
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
+    <version.org.codehaus.castor>1.4.1</version.org.codehaus.castor>
 
     <!-- Using origin-repository.jboss.org as that is the canonical URL for deployment. repository.jboss.org is just a proxy
          which should delegate the calls to origin-repository.jboss.org, but that is often buggy. Using the canonical URL
          directly should help to avoid some of the issues with deploying artifacts. -->
     <jboss.releases.repo.url>https://origin-repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
     <jboss.snapshots.repo.url>https://origin-repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
+
   </properties>
 
   <repositories>
@@ -338,7 +340,7 @@
                 <checkstyleRules>
                   <module name="Checker">
                     <module name="FileTabCharacter">
-                      <property name="eachLine" value="true"/>
+                      <property name="eachLine" value="true" />
                     </module>
                   </module>
                 </checkstyleRules>
@@ -923,7 +925,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore/>
+                    <ignore />
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -1663,7 +1665,7 @@
         <version>${version.org.jboss.resteasy}</version>
       </dependency>
 
-      <!-- Required for Errai Dynamic Bean validation  -->
+      <!-- Required for Errai Dynamic Bean validation -->
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
@@ -1687,6 +1689,57 @@
         <classifier>sources</classifier>
       </dependency>
 
+      <dependency>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctorj-pdf</artifactId>
+        <version>${version.org.asciidoctor.pdf}</version>
+      </dependency>
+
+      <!-- Dependencies for drools-compiler XSD-based Java class generation -->
+      <dependency>
+        <groupId>org.codehaus.castor</groupId>
+        <artifactId>castor-codegen</artifactId>
+        <version>${version.org.codehaus.castor}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.castor</groupId>
+        <artifactId>castor-core</artifactId>
+        <version>${version.org.codehaus.castor}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.castor</groupId>
+        <artifactId>castor-xml</artifactId>
+        <version>${version.org.codehaus.castor}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.castor</groupId>
+        <artifactId>castor-xml-schema</artifactId>
+        <version>${version.org.codehaus.castor}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
**Do not close: working on a JiBX based solution and will `push -f` those commits soon.**

Related PR's: 
- https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/239
- https://github.com/droolsjbpm/droolsjbpm-knowledge/pull/149
- https://github.com/droolsjbpm/drools/pull/836

