### PR TITLE
Upgrade Cargo from 1.4.19 to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <version.net.sf.docbook.docbook-xsl>1.76.1</version.net.sf.docbook.docbook-xsl>
     <version.org.apache.xmlgraphics.commons>1.4</version.org.apache.xmlgraphics.commons>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
-    <version.org.codehaus.cargo>1.4.19</version.org.codehaus.cargo>
+    <version.org.codehaus.cargo>1.5.0</version.org.codehaus.cargo>
     <version.org.jboss.arquillian.extension.drone>2.0.0.Final</version.org.jboss.arquillian.extension.drone>
     <version.org.jboss.arquillian.graphene>2.1.0.CR1</version.org.jboss.arquillian.graphene>
     <version.org.drools.guvnor-api>5.6.0.Final</version.org.drools.guvnor-api>


### PR DESCRIPTION
 * 1.5.0 brings support for EAP 6.4.7+

cc @mswiderski, @sutaakar 