### PR TITLE
Upgrade Cargo from 1.4.19 to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven2-plugin</artifactId>
-          <version>1.4.19</version>
+          <version>1.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
 * 1.5.0 brings support for EAP 6.4.7+

Backport of #245 