### PR TITLE
Upgrade to GWT 2.8.0-rc1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,9 +112,11 @@
     <version.org.jboss.jboss-dmr>1.3.0.Final</version.org.jboss.jboss-dmr>
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
-    <version.com.google.gwt>2.8.0-beta1</version.com.google.gwt>
+    <version.com.google.gwt>2.8.0-rc1</version.com.google.gwt>
+    <!-- TODO Remove this when gson version is updated in ip-bom -->
+    <version.com.google.code.gson>2.6.2</version.com.google.code.gson>
     <!-- 19.0.0.jbossorg-2 was created from upstream Guava version 20.0-SNAPSHOT as Errai 4.0/GWT 2.8 needs it. Once the version 20.0 is released, we should upgrade to that. -->
-    <version.com.google.guava>19.0.0.jbossorg-2</version.com.google.guava>
+    <version.com.google.guava>19.0.0.jbossorg-2</version.com.google.guava>    
     <!-- this version will overwrite jboss-ip-version 3.1.2. The version in jboss-ip-bom couldn't be upgraded as this version needs GWT 2.7.0 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
@@ -1454,6 +1456,16 @@
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-dev</artifactId>
         <version>${version.com.google.gwt}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>          
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Most external dependencies that used to be inside the gwt-dev.jar have now been unbundled. So we can get rid of the enforcer exception and can now manage exclusions using the standard maven mechanism.