### PR TITLE
gwt-maven-plugin: don't print entire java command on error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -854,6 +854,7 @@
           <configuration>
             <localWorkers>${gwt.compiler.localWorkers}</localWorkers>
             <strict>true</strict>
+            <printJavaCommandOnError>false</printJavaCommandOnError>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
 * the java command also contains the whole classpath, which
   in our case means literally thousands of characters. Leaving
   out the command makes the Maven build log much cleaner. It is
   now also much easier to find the actual root cause of the
   failed GWT compilation

The quest for clean GWT build logs in almost complete! Only one PR away :)

CC @csadilek 