### PR TITLE
[6.5.x] Use property to easily enable/disable checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,8 @@
     <!-- Override6.1.1 is the last version supporting Java 6. We need to be able to run certain modules
          (e.g. jbpm-test-coverage) with Java 6. -->
     <version.checkstyle>6.1.1</version.checkstyle>
-
+    <!-- TODO: remove this once all repositories comply to the defined checkstyle rules -->
+    <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
     <!-- org.eclipse.tycho plugin version -->
     <version.org.eclipse.tycho>0.24.0</version.org.eclipse.tycho>
     <version.org.jboss.tools.tycho-plugins>0.23.1</version.org.jboss.tools.tycho-plugins>
@@ -298,6 +299,7 @@
                 <checkstyleRules>
                   <module name="Checker">
                     <module name="FileTabCharacter">
+                      <property name="severity" value="error"/>
                       <property name="eachLine" value="true"/>
                     </module>
                   </module>
@@ -308,7 +310,6 @@
                 <includeTestResources>true</includeTestResources>
                 <consoleOutput>false</consoleOutput>
                 <logViolationsToConsole>false</logViolationsToConsole>
-                <failOnViolation>false</failOnViolation>
                 <failsOnError>false</failsOnError>
               </configuration>
             </execution>


### PR DESCRIPTION
 * the failOnValidation is false by default since
   most of the repos would fail on that. One repo
   at the time, we need to fix them, override
   the property there (temporarily) and once all
   repos comply, we can also change the property
   value here