### PR TITLE
RHBRMS-2525: Business-central startup error: jGIT: Cannot run program 'bash'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,10 @@
     <version.org.codehaus.cargo>1.5.0</version.org.codehaus.cargo>
     <version.org.jboss.arquillian.extension.drone>2.0.0.Final</version.org.jboss.arquillian.extension.drone>
     <version.org.jboss.arquillian.graphene>2.1.0.CR1</version.org.jboss.arquillian.graphene>
+
+    <!-- JGIT 4.4.1.201607150455-r override can be removed once we use IP BOM which includes https://github.com/jboss-integration/jboss-integration-platform-bom/pull/327 -->
+    <version.org.eclipse.jgit>4.4.1.201607150455-r</version.org.eclipse.jgit>
+
     <version.org.drools.guvnor-api>5.6.0.Final</version.org.drools.guvnor-api>
     <version.org.jboss.errai>4.0.0-SNAPSHOT</version.org.jboss.errai>
     <!-- Version of Errai compatible with CDI 1.0. Few artifacts in this version are used for CDI 1.0 compatible WAR distributions. -->


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2525

This overrides the version in ip-bom until we move to a version containing https://github.com/jboss-integration/jboss-integration-platform-bom/pull/327