### PR TITLE
Fix build on Java 8: disable javadoc doclint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+    <!-- exposed additional params for javadoc, such as Xlint -->
+    <javadoc.additional.params />
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
     <!-- org.eclipse.tycho plugin version -->
@@ -848,6 +850,7 @@
             <author>false</author>
             <breakiterator>true</breakiterator>
             <quiet>true</quiet>
+            <additionalparam>${javadoc.additional.params}</additionalparam>
           </configuration>
         </plugin>
         <plugin>
@@ -1135,6 +1138,16 @@
         <osgi.snapshot.qualifier>qualifier</osgi.snapshot.qualifier>
       </properties>
     </profile>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.additional.params>-Xdoclint:none</javadoc.additional.params>
+      </properties>
+    </profile>
+
   </profiles>
 
   <modules>


### PR DESCRIPTION
 * Java 8 javadoc tool is more strict and fails the build.
   This has been already fixed on newer branches

@manstis this should fix the PR builds on 6.3.x branch