### PR TITLE
[DROOLS-898] rename drools-osgi to kie-osgi

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -428,31 +428,31 @@
         <classifier>sources</classifier>
       </dependency>
       <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-osgi-integration</artifactId>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-osgi-integration</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-osgi-integration</artifactId>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-osgi-integration</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-karaf-features</artifactId>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-karaf-features</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-karaf-features</artifactId>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-karaf-features</artifactId>
         <version>${version.org.kie}</version>
         <classifier>features</classifier>
         <type>xml</type>
       </dependency>
       <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-karaf-itests</artifactId>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-karaf-itests</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
          See https://issues.apache.org/jira/browse/FELIX-4882 for more details.
          Version 3.x requires Java 7 (not directly, but one of transitive deps does). -->
     <version.bundle.plugin>2.5.3</version.bundle.plugin>
-    <!-- Surefire version 2.19.1 coming from parent is buggy and drools-osgi tests in droolsjbpm-integration are failing because of that. -->
+    <!-- Surefire version 2.19.1 coming from parent is buggy and kie-osgi tests in droolsjbpm-integration are failing because of that. -->
     <version.surefire.plugin>2.18.1</version.surefire.plugin>
 
     <!-- TODO: remove this once all repositories comply to the defined checkstyle rules -->


### PR DESCRIPTION
All related PRs:
https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/274
https://github.com/droolsjbpm/drools/pull/902
https://github.com/droolsjbpm/droolsjbpm-integration/pull/631