### PR TITLE
RHBRMS-2552 Define a property for the latest Kie release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,9 @@
          directly should help to avoid some of the issues with deploying artifacts. -->
     <jboss.releases.repo.url>https://origin-repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
     <jboss.snapshots.repo.url>https://origin-repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
+
+    <!-- Latest release to be used by api-compatibility-check to check backwards compat of the Kie API. -->
+    <version.org.kie.latestFinal.release>6.4.0.Final</version.org.kie.latestFinal.release>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Define a property for the latest Kie release, to be used in
droolsjbpm-knowledge/kie-api when checking API compatibility,
this allows productization to override this.

Latest Kie release property updated for consistency.

(cherry picked from commit bda543dda9bd0ec3b47cc1f9c03941f96f3c9178)

@psiroky Here you go :)