### PR TITLE
GUVNOR-2722: i18n: Host JSP's do not use correct Locale when the User has configured multiple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -828,7 +828,10 @@
             <projectConfig>${session.executionRootDirectory}/src/main/config/zanata.xml</projectConfig>
             <srcDir>src/main/resources/</srcDir>
             <transDir>src/main/resources/</transDir>
-            <includes>**/*Constants.properties</includes>
+            <includes>
+              <include>**/*Constants.properties</include>
+              <include>**/*Constants_en.properties</include>
+            </includes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2722

Ensure the ```LoginConstants_en.properties``` files are pushed to Zanata as a source file.