### PR TITLE
[6.5.x] GUVNOR-2722: i18n: Host JSP's do not use correct Locale when the User has configured multiple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,10 @@
             <projectConfig>${session.executionRootDirectory}/src/main/config/zanata.xml</projectConfig>
             <srcDir>src/main/resources/</srcDir>
             <transDir>src/main/resources/</transDir>
-            <includes>**/*Constants.properties</includes>
+            <includes>
+              <include>**/*Constants.properties</include>
+              <include>**/*Constants_en.properties</include>
+            </includes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2722

This is the corollary of https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/294 for 6.5.x

(cherry picked from commit 98271587b5e2aa9153539329e55129bdec945fe9)