### PR TITLE
Revert "GUVNOR-2722: i18n: Host JSP's do not use correct Locale when …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -828,10 +828,7 @@
             <projectConfig>${session.executionRootDirectory}/src/main/config/zanata.xml</projectConfig>
             <srcDir>src/main/resources/</srcDir>
             <transDir>src/main/resources/</transDir>
-            <includes>
-              <include>**/*Constants.properties</include>
-              <include>**/*Constants_en.properties</include>
-            </includes>
+            <includes>**/*Constants.properties</includes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
…the User has configured multiple (#294)"

This reverts commit ccbd2e55b0662a0c00dce85688d785434e17be89.
This commit has to be reverted as it brings zanata:push module to fail.