### PR TITLE
Revert "GUVNOR-2722: i18n: Host JSP's do not use correct Locale when …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -781,10 +781,7 @@
             <projectConfig>${session.executionRootDirectory}/src/main/config/zanata.xml</projectConfig>
             <srcDir>src/main/resources/</srcDir>
             <transDir>src/main/resources/</transDir>
-            <includes>
-              <include>**/*Constants.properties</include>
-              <include>**/*Constants_en.properties</include>
-            </includes>
+            <includes>**/*Constants.properties</includes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
…the User has configured multiple (#295)"

This reverts commit 0b808b7acb166c13f2bfe5eb79b6a307721708cd.
This commit has to be reverted as it brings zanata:push module to fail.