### PR TITLE
GUVNOR-2722: i18n: Host JSP's do not use correct Locale when the User has configured multiple. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -828,7 +828,7 @@
             <projectConfig>${session.executionRootDirectory}/src/main/config/zanata.xml</projectConfig>
             <srcDir>src/main/resources/</srcDir>
             <transDir>src/main/resources/</transDir>
-            <includes>**/*Constants.properties</includes>
+            <includes>**/*Constants.properties,**/*Constants_en.properties</includes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Correct <includes> element.

@mbiarnes Hi, could you please approve?

I've tested with ```mvn zanata:push-module -B``` on ```kie-wb-distributions``` and it was fine.