### PR TITLE
[6.5.x] GUVNOR-2722: i18n: Host JSP's do not use correct Locale when the User has configured multiple. Correct <includes> element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,7 @@
             <projectConfig>${session.executionRootDirectory}/src/main/config/zanata.xml</projectConfig>
             <srcDir>src/main/resources/</srcDir>
             <transDir>src/main/resources/</transDir>
-            <includes>**/*Constants.properties</includes>
+            <includes>**/*Constants.properties,**/*Constants_en.properties</includes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Correct element.

This is the corollary of https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/299 for 6.5.x

(cherry picked from commit 757b5b2c42251f88e2984e0b8fda40fc85f8d268)