### PR TITLE
RHBPMS-4360: upgrade jgit version in order to avoid windows issues on high concurrency situations.

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -374,6 +374,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.eclipse.jgit</groupId>
+        <artifactId>org.eclipse.jgit</artifactId>
+        <version>${version.org.eclipse.jgit}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.inject</artifactId>
         <version>${version.org.eclipse.sisu}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
     <version.org.geronimo.atinject>1.0</version.org.geronimo.atinject>
     <!-- since ironjacamar was removed from the ip-ip-bom but is still needed from dashboard-builder all dependencies are placed here -->
     <version.org.jboss.ironjacamar>1.0.31.Final</version.org.jboss.ironjacamar>
+    <!-- jgit upgrade that breaks java 1.6 compatibility -->
+    <version.org.eclipse.jgit>4.4.1.201607150455-r</version.org.eclipse.jgit>
     <!-- In community builds productized is false, in product builds it's true to enable branding changes -->
     <org.kie.productized>false</org.kie.productized>
 
@@ -145,9 +147,12 @@
     <!-- org.eclipse.tycho plugin version -->
     <version.org.eclipse.tycho>0.24.0</version.org.eclipse.tycho>
     <version.org.jboss.tools.tycho-plugins>0.23.1</version.org.jboss.tools.tycho-plugins>
-    
+
+    <!-- Override Java source/target to be 1.7 -->
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
     <!-- Used by maven-enforcer-plugin -->
-    <!-- IMPORTANT: JDK8 is needed to build the projects (to support also WildFly 10), but we still do support JDK6/JDK7 for all backend modules. -->
+    <!-- IMPORTANT: JDK8 is needed to build the projects (to support also WildFly 10), but we still do support JDK7 for all backend modules. -->
     <jdk.min.version>1.8</jdk.min.version>
     <maven.min.version>3.2.3</maven.min.version>
     <!-- Important: this is one and only place where the supported user agents (browsers) are configured.
@@ -342,7 +347,7 @@
           </dependencies>
           <executions>
             <execution>
-              <id>check-java-1.6-compatibility</id>
+              <id>check-java-1.7-compatibility</id>
               <phase>test-compile</phase>
               <goals>
                 <goal>check</goal>
@@ -350,8 +355,8 @@
               <configuration>
                 <signature>
                   <groupId>org.codehaus.mojo.signature</groupId>
-                  <artifactId>java16</artifactId>
-                  <version>1.1</version>
+                  <artifactId>java17</artifactId>
+                  <version>1.0</version>
                 </signature>
               </configuration>
             </execution>


### PR DESCRIPTION
Important note: the jgit upgrade requires Java7+, so this is also removing 1.6 support from the build.