### PR TITLE
Bump minimal required Maven version from 3.2.3 to 3.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Installing Maven
 
             ```shell
             $ cd ~/opt/build/
-            $ ln -s apache-maven-3.0.3 apache-maven
+            $ ln -s apache-maven-3.2.5 apache-maven
             ```
 
             Next time you only have to remove the link and recreate the link to the new version.
@@ -335,7 +335,7 @@ Installing Maven
         * Add this to your `~/.bashrc` file:
 
             ```shell
-            export MAVEN_OPTS="-Xms256m -Xmx1024m -XX:MaxPermSize=512m"
+            export MAVEN_OPTS="-Xms256m -Xmx1024m"
             ```
 
 * Windows:
@@ -345,15 +345,15 @@ Installing Maven
         * Open menu *Configuration screen*, menu item *System*, tab *Advanced*, button *environment variables*:
 
             ```shell
-            set MAVEN_OPTS="-Xms256m -Xmx1024m -XX:MaxPermSize=512m"
+            set MAVEN_OPTS="-Xms256m -Xmx1024m"
             ```
 
 * Check if maven is installed correctly.
 
     ```shell
     $ mvn --version
-    Apache Maven 3.0.3 (...)
-    Java version: 1.6.0_24
+    Apache Maven 3.2.5 (...)
+    Java version: 1.8.0_112
     ```
 
     Note: the enforcer plugin enforces a minimum maven and java version.

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <version.org.eclipse.tycho>0.24.0</version.org.eclipse.tycho>
     <version.org.jboss.tools.tycho-plugins>0.23.1</version.org.jboss.tools.tycho-plugins>
 
-    <maven.min.version>3.2.3</maven.min.version>
+    <maven.min.version>3.2.5</maven.min.version>
     <!-- Important: this is one and only place where the supported user agents (browsers) are configured.
          All webapps/showcases must use this property in their *.gwt.xml files.
          We only need to support IE11+, but there is no ie11 permutation. IE11 will use the Firefox one (gecko1_8) -->


### PR DESCRIPTION
@mbiarnes could you please take a look? We need to upgrade the Jenkins jobs to use the newer Maven version. I believe I did most of the updates already, but if you find anything else that is missing, please let me know.