### PR TITLE
maven-compiler-plugin: disable forking + remove duplicated config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,20 +438,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <fork>true</fork>
-            <meminitial>128m</meminitial>
-            <maxmem>512m</maxmem>
-            <showDeprecation>true</showDeprecation>
-            <showWarnings>true</showWarnings>
-            <source>${maven.compiler.argument.source}</source>
-            <target>${maven.compiler.argument.target}</target>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <includes>


### PR DESCRIPTION
 * jboss-parent already defines source, target, warnings and deprecation
 * fork config removed == forking disabled (default is false)
 * meminitial and memmax are only needed when forking
 * compile-only builds are 60 % faster with forking disabled

@mbiarnes, @ge0ffrey I don't know if there was a specific reason to always fork the compiler, do you remember? 