### PR TITLE
No empty lines before '}' allowed

### DIFF
--- a/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
+++ b/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
@@ -68,7 +68,7 @@
   <codeStyleSettings language="JAVA">
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
     <option name="IF_BRACE_FORCE" value="3" />


### PR DESCRIPTION
This PR remove all empty lines before '}' symbol. For example:

```java
class SomeClass {

     public void emptyMethod() {

     }

    public void someMethod() {
         System.out.println("Hello World");

    }

}
```

will be replaced to:

```java
class SomeClass {

    public void emptyMethod() {
    }

    public void someMethod() {
        System.out.println("Hello World");
    }
}
```

To check this PR you can use IntelliJ editor:
File -> Settings -> Editor -> Code Style -> Java -> Blank Lines -> Keep Maximum Blank Lines -> Before '}':