### PR TITLE
Update revapi to 0.8.1/0.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,43 @@
               <version>0.11.2</version>
             </dependency>
           </dependencies>
+          <configuration>
+            <oldArtifacts>
+              <artifact>${project.groupId}:${project.artifactId}:${version.org.kie.latestFinal.release}</artifact>
+            </oldArtifacts>
+            <!-- By default revapi will check the oldArtifact against the currently executed build -->
+            <analysisConfigurationFiles>
+              <configurationFile>
+                <path>src/build/revapi-config.json</path>
+              </configurationFile>
+            </analysisConfigurationFiles>
+            <!-- By default, revapi will only fail the build if there are potentially breaking or breaking changes. However, in the report
+                 we want even non breaking changes to be present. -->
+            <reportSeverity>nonBreaking</reportSeverity>
+            <failSeverity>potentiallyBreaking</failSeverity>
+          </configuration>
+          <!-- Running two executions is a workaround to make sure we get a HTML report in case revapi finds
+               some incompatible changes. The "check" goal will simply fail the whole build before it could get
+               to the report. To make sure we always get a HTML report, the "report" goal needs to be executed
+               before the "check" goal.
+               Once https://github.com/revapi/revapi/issues/11 is fixed it should be possible to use single execution. -->
+          <executions>
+            <execution>
+              <id>check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+            <execution>
+              <!-- report can be found in ${build.directory}/site/revapi-report.html -->
+              <id>report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <phase>package</phase>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -379,12 +379,12 @@
         <plugin>
           <groupId>org.revapi</groupId>
           <artifactId>revapi-maven-plugin</artifactId>
-          <version>0.6.1</version>
+          <version>0.7.0</version>
           <dependencies>
             <dependency>
               <groupId>org.revapi</groupId>
               <artifactId>revapi-java</artifactId>
-              <version>0.10.2</version>
+              <version>0.11.2</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <jboss.snapshots.repo.url>https://origin-repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <version.org.kie.latestFinal.release>6.4.0.Final</version.org.kie.latestFinal.release>
+    <version.org.kie.latestFinal.release>6.5.0.Final</version.org.kie.latestFinal.release>
 
     <!-- using undertow for kie server router - same version as it comes with WildFly 10.0.0.Final-->
     <version.io.undertow.core>1.3.15.Final</version.io.undertow.core>
@@ -379,12 +379,12 @@
         <plugin>
           <groupId>org.revapi</groupId>
           <artifactId>revapi-maven-plugin</artifactId>
-          <version>0.7.0</version>
+          <version>0.8.1</version>
           <dependencies>
             <dependency>
               <groupId>org.revapi</groupId>
               <artifactId>revapi-java</artifactId>
-              <version>0.11.2</version>
+              <version>0.13.1</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
Hi,

I have updated revapi plugin to 0.8.1 and its Java extension to 0.13.1. It should be a lot better according to an author. Please do not merge it yet.

Thanks,

Marian
