### PR TITLE
Configure imports settings for stylecheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 /local
 
 # Eclipse, Netbeans and IntelliJ files

--- a/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
+++ b/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
@@ -1,7 +1,7 @@
 <code_scheme name="KIE Java Conventions">
   <option name="LINE_SEPARATOR" value="&#xA;" />
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
   <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
     <value>
       <package name="org.junit.Assert" withSubpackages="true" static="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,21 @@
                       <property name="severity" value="error"/>
                       <property name="eachLine" value="true"/>
                     </module>
+                    <module name="TreeWalker">
+                      <!-- Import settings: getting rid of redundant import, forbid star notation, defined order of imports. -->
+                      <module name="RedundantImport"/>
+                      <module name="AvoidStarImport">
+                        <property name="excludes" value="org.junit.Assert,org.assertj.core.api.Assertions,org.mockito.Mockito"/>
+                        <property name="allowClassImports" value="false"/>
+                        <property name="allowStaticMemberImports" value="false"/>
+                      </module>
+                      <module name="CustomImportOrder">
+                        <property name="customImportOrderRules"
+                                  value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###STATIC"/>
+                        <property name="sortImportsInGroupAlphabetically" value="true"/>
+                        <property name="separateLineBetweenGroups" value="true"/>
+                      </module>
+                    </module>
                   </module>
                 </checkstyleRules>
                 <outputFile>${project.build.directory}/checkstyle.log</outputFile>


### PR DESCRIPTION
+ Fix for IDEA config file (disable star notation for *static* imports)
+ gitignore target folder not only in root but also for all sub directories (we need it for dashboard-builder-bom folder)