### PR TITLE
Upgrade cargo-maven2-plugin from 1.5.0 to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <version.org.apache.pdfbox>1.8.6</version.org.apache.pdfbox> <!-- Remove after upgrading to IP BOM 7.0.0.CR6 -->
     <version.org.apache.xmlgraphics.commons>1.4</version.org.apache.xmlgraphics.commons>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
-    <version.org.codehaus.cargo>1.5.0</version.org.codehaus.cargo>
+    <version.org.codehaus.cargo>1.6.2</version.org.codehaus.cargo>
     <version.org.jboss.arquillian.extension.drone>2.0.0.Final</version.org.jboss.arquillian.extension.drone>
     <version.org.jboss.arquillian.graphene>2.1.0.CR1</version.org.jboss.arquillian.graphene>
 


### PR DESCRIPTION
Test component - used for controlling of application servers during integration tests.