### PR TITLE
Upgrade Weld to 2.4.1.Final + Weld API to 2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,9 @@
     <!-- Version of the KIE Workbench application. Shown for example in About dialog. Will be usually overridden by productisation. -->
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
 
+    <!-- TODO: remove the Weld + Weld API override once we upgrade to IP BOM 7.0.0.CR7+-->
+    <version.org.jboss.weld.weld>2.4.1.Final</version.org.jboss.weld.weld>
+    <version.org.jboss.weld.weld-api>2.4.Final</version.org.jboss.weld.weld-api>
     <version.org.wildfly.swarm>2016.9</version.org.wildfly.swarm>
     <version.net.byte-buddy>1.4.16</version.net.byte-buddy>
     <version.commons-beanutils>1.9.2</version.commons-beanutils>


### PR DESCRIPTION
This is needed to fix the compatibility issue with Jandex 2.x.

It's just temporary override and shoud be removed once we upgrade
to IP BOM 7.0.0.CR7+.