### PR TITLE
Stylecheck settings for Imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,21 @@
                       <property name="severity" value="error"/>
                       <property name="eachLine" value="true"/>
                     </module>
+                    <module name="TreeWalker">
+                      <!-- Import settings: getting rid of redundant import, forbid star notation, defined order of imports. -->
+                      <module name="RedundantImport"/>
+                      <module name="AvoidStarImport">
+                        <property name="excludes" value="org.junit.Assert,org.assertj.core.api.Assertions,org.mockito.Mockito"/>
+                        <property name="allowClassImports" value="false"/>
+                        <property name="allowStaticMemberImports" value="false"/>
+                      </module>
+                      <module name="CustomImportOrder">
+                        <property name="customImportOrderRules"
+                                  value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###STATIC"/>
+                        <property name="sortImportsInGroupAlphabetically" value="true"/>
+                        <property name="separateLineBetweenGroups" value="true"/>
+                      </module>
+                    </module>
                   </module>
                 </checkstyleRules>
                 <outputFile>${project.build.directory}/checkstyle.log</outputFile>


### PR DESCRIPTION
Part of https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/342 about CheckStyle configuration. We had to split it because we need to use IDEA style plugin to reformat Stunner before CheckStyle will be configured.