### PR TITLE
Wrap and align implemented interfaces, method declaration parameters and method call parameters

### DIFF
--- a/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
+++ b/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
@@ -1,5 +1,5 @@
 <code_scheme name="KIE Java Conventions">
-  <option name="LINE_SEPARATOR" value="&#xA;" />
+  <option name="LINE_SEPARATOR" value="&#10;" />
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
   <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
@@ -70,7 +70,12 @@
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="2" />
+    <option name="METHOD_PARAMETERS_WRAP" value="2" />
+    <option name="EXTENDS_LIST_WRAP" value="2" />
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />


### PR DESCRIPTION
Following the discussion with @hasys on https://github.com/droolsjbpm/kie-wb-common/pull/634 I fetched the latest IDEA code-formatter. Much to my surprise it generated quite different code format to (a) I am used to, (b) that appears to be used by the vast majority of other developers.

This PR therefore reinstates spaces 'within' constructs that appeared to be the norm in older versions of this code formatter and most certainly older versions of IDEA. Possibly affected by dc77c93f9d60507382831612f6ddf0024abba02a