### PR TITLE
Roaster version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,10 @@
 
     <!-- using undertow for kie server router - same version as it comes with WildFly 10.0.0.Final-->
     <version.io.undertow.core>1.3.15.Final</version.io.undertow.core>
+
+    <!-- Overrides the version in the jboss-integration-platform-bom. A peer PR will be sent to jboss-integration-platform project.
+         Please move this new version number there when possible -->
+    <version.org.jboss.forge.roaster>2.19.4.Final</version.org.jboss.forge.roaster>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Hello @psiroky @csadilek @mcimbora @ge0ffrey 

This PR is a proposal for upgrading the Roaster library we are currently using for java  files parsing/editing from current version in use: 2.13.0.Final (Feb, 2015) to the last version 2.19.4.Final (Dec, 2016).

Additionally to some bugs fixing, this version also benefits from an upgraded eclipse jdt compiler version that is used internally by Roaster.

To be honest I don't know exactly if we have a policy for this versions upgrades, but I believe it might be worth to do the update.

In general I checked in my local that everything works ok with the new library, and that the tests continues running etc. Only a minor change in a piece of code is needed to change, but all our internal APIs remains the same, and the same for all our tests, etc. (so if we proceed a minimal PR is required for kie-wb-commons)

wdyt?

Regards,
Walter.

P.S. If we proceed with the upgrade we can then send a PR to the jboss-integration-platform-bom project.
