### PR TITLE
[6.5.x] RHBPMS-4602: LinkageError during invocation of webservice workitem on WAS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
     <version.org.jboss.xnio>3.2.0.Final</version.org.jboss.xnio>
     <!-- version of org.jboss.xnio aligned with WildFly 10 -->
     <version.org.jboss.xnio.wildfly10>3.3.6.Final</version.org.jboss.xnio.wildfly10>
-    <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
     <version.org.drools.guvnor-api>5.6.0.Final</version.org.drools.guvnor-api>
     <version.org.jboss.errai>3.2.5.Final</version.org.jboss.errai>
     <!-- Version of Errai compatible with CDI 1.0. Few artifacts in this version are used for CDI 1.0 compatible WAR distributions. -->


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4602

This is the corollary of https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/372 for 6.5.x