### PR TITLE
Next portion of checkStyle modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,11 @@
                         <property name="sortImportsInGroupAlphabetically" value="true"/>
                         <property name="separateLineBetweenGroups" value="true"/>
                       </module>
+
+                      <module name="NeedBraces">
+                        <property name="tokens" value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+                      </module>
+                      <module name="EqualsHashCode"/>
                     </module>
                   </module>
                 </checkstyleRules>
@@ -1295,7 +1300,7 @@
           </exclusion>
         </exclusions>
       </dependency>
-      
+
       <!-- TODO BZ-996210 use org.apache.xmlgraphics:batik* instead -->
       <dependency>
         <groupId>batik</groupId>


### PR DESCRIPTION
This PR enables following modules:

**NeedBraces**
Checks for braces around code blocks.
if, else, for, while, do...while.

**EqualsHashCode**
Checks that classes that either override equals() or hashCode() also overrides the other. This checks only verifies that the method declarations match Object.equals(Object)} and Object.hashCode() exactly to be considered an override. This check does not verify invalid method names, parameters other than Object, or anything else.

**UnusedImports**
Checks for unused import statements. Checkstyle uses a simple but very reliable algorithm to report on unused import statements. An import statement is considered unused if:
- It is not referenced in the file. The algorithm does not support wild-card imports like import java.io.*;. Most IDE's provide very sophisticated checks for imports that handle wild-card imports.
- It is a duplicate of another import. This is when a class is imported more than once.
- The class imported is from the java.lang package. For example importing java.lang.String.
- The class imported is from the same package.