### PR TITLE
enable code-coverage for GwtMockito tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,20 @@ Guvnor uses Arquillian to run tests in a J2EE container and hence tests need to 
     $ mvn test [-Dtest=ATestClassName]
     ```
 
+Running code-coverage checks
+----------------------------
+
+JaCoCo plugin allows to measure code-coverage for any child of droolsjbpm-build-bootstrap. 
+The check binds to the verify phase and for the plugin to run, the code-coverage profile has to be enabled.
+
+* From the module/project folder run command:
+   
+    ```shell
+    $ mvn clean verify -Pcode-coverage
+    ```
+
+* The coverage report is then generated in ./target/site/jacoco/index.html
+
 Configuring Maven
 -----------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -589,13 +589,16 @@
           <version>${version.jacoco.plugin}</version>
           <executions>
             <execution>
-              <id>default-prepare-agent</id>
+              <id>default-instrument</id>
               <goals>
-                <goal>prepare-agent</goal>
+                <goal>instrument</goal>
               </goals>
-              <configuration>
-                <propertyName>surefire.argLine</propertyName>
-              </configuration>
+            </execution>
+            <execution>
+              <id>default-restore-instrumented-classes</id>
+              <goals>
+                <goal>restore-instrumented-classes</goal>
+              </goals>
             </execution>
             <execution>
               <id>default-report</id>
@@ -1152,6 +1155,14 @@
           <name>code-coverage</name>
         </property>
       </activation>
+      <dependencies>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <pluginManagement>
           <plugins>
@@ -1159,8 +1170,9 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
-                <!-- Append surefire.argLine property populated by JaCoCo plugin -->
-                <argLine>-Xmx1024m -Dfile.encoding=UTF-8 @{surefire.argLine}</argLine>
+                <systemPropertyVariables>
+                  <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                </systemPropertyVariables>
               </configuration>
             </plugin>
           </plugins>
@@ -1503,6 +1515,13 @@
             <artifactId>guice</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>org.jacoco.agent</artifactId>
+        <version>${version.jacoco.plugin}</version>
+        <classifier>runtime</classifier>
       </dependency>
 
       <!-- Errai (needed for Guice exclusion) -->


### PR DESCRIPTION
By default jacoco java agent instruments classes on-the-fly during the test execution. This simplifies code coverage analysis a lot, as no pre-instrumentation and classpath tweaking is required.
However when using tests with custom classloader (tests that run with GwtMockitoTestRunner.class) the jacoco plugin shows zero coverage. This is because the ids of the classes in the report (jacoco.exec)
do not match the ids of the actual classes in the project (as GwtMockito uses proxies of the classes that are being tested). This problem has been solved by setting jacoco plugin to instrument
the classes before the test are run (and the proxies are created). This way exection report info is created from the original classes instead of the created proxies. The result is that the coverage of both
GwtMockito and "normal" tests can be measured. No negative side-effects (slowdown or misleading info in the report) have been observed.