### PR TITLE
Move findbugs configuration to kie-parent

### DIFF
--- a/kie-build-tools/pom.xml
+++ b/kie-build-tools/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>kie-user-bom-parent</artifactId>
+    <groupId>org.kie</groupId>
+    <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../kie-user-bom-parent/pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kie-build-tools</artifactId>
+
+  <name>KIE build tools</name>
+  <description>
+    Contains common configuration shared across KIE projects.
+  </description>
+
+</project>

--- a/kie-build-tools/src/main/resources/findbugs-excludes.xml
+++ b/kie-build-tools/src/main/resources/findbugs-excludes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <!-- CDI requires non-private zero-arg constructor to exist. -->
+    <Bug pattern="NP_NULL_PARAM_DEREF_NONVIRTUAL"/>
+  </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,8 @@
     <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
     <!-- TODO: remove this once all repositories/modules are fixed and do not contain duplicated classes -->
     <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>
+    <!-- Set to "true" on every project that has no violations. -->
+    <findbugs.failOnViolation>false</findbugs.failOnViolation>
     <!-- org.eclipse.tycho plugin version -->
     <version.org.eclipse.tycho>0.24.0</version.org.eclipse.tycho>
     <version.org.jboss.tools.tycho-plugins>0.23.1</version.org.jboss.tools.tycho-plugins>
@@ -1067,6 +1069,33 @@
           <artifactId>wildfly-swarm-plugin</artifactId>
           <version>${version.org.wildfly.swarm}</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>org.kie</groupId>
+              <artifactId>kie-build-tools</artifactId>
+              <version>${version.org.kie}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <maxRank>6</maxRank>
+            <effort>Max</effort>
+            <xmlOutput>true</xmlOutput>
+            <failOnError>${findbugs.failOnViolation}</failOnError>
+            <excludeFilterFile>findbugs-excludes.xml</excludeFilterFile>
+          </configuration>
+          <executions>
+            <execution>
+              <id>findbugs-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>compile</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -1153,8 +1182,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <!-- Keep in sync with <build><plugins> -->
-        <version>2.5.5</version>
       </plugin>
     </plugins>
   </reporting>
@@ -1221,6 +1248,10 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>
@@ -1306,6 +1337,7 @@
   </profiles>
 
   <modules>
+    <module>kie-build-tools</module>
     <module>kie-user-bom-parent</module>
     <module>kie-bom</module>
     <module>drools-bom</module>


### PR DESCRIPTION
Moves findbugs configuration to kie-parent and shows example of excluding an individual pattern. As findbugs maven plugin accepts only inclusion/exclusion filter files, this piece of configuration has to be distributed amongst KIE projects as a standalone artifact (common-build-tools).

To run findbugs, activate the `fullProfile`. Once all violations in a project have been fix, override the `findbugs.failOnViolation` property to avoid introducing new.