### PR TITLE
JBPM-5708 MapDB implementation of persistence for Drools and jBPM

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -176,6 +176,40 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-api</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-api</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-api</artifactId>
+        <type>test-jar</type>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-mapdb</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-mapdb</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-mapdb</artifactId>
+        <type>test-jar</type>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
         <artifactId>drools-persistence-jpa</artifactId>
         <version>${version.org.kie}</version>
       </dependency>

--- a/jbpm-bom/pom.xml
+++ b/jbpm-bom/pom.xml
@@ -102,6 +102,40 @@
       </dependency>
       <dependency>
         <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-persistence-api</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-persistence-api</artifactId>
+        <type>test-jar</type>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-persistence-api</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-persistence-mapdb</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-persistence-mapdb</artifactId>
+        <type>test-jar</type>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-persistence-mapdb</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
         <artifactId>jbpm-persistence-jpa</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
@@ -355,6 +389,17 @@
        <dependency>
          <groupId>org.jbpm</groupId>
          <artifactId>jbpm-human-task-jpa</artifactId>
+         <version>${version.org.kie}</version>
+         <classifier>sources</classifier>
+       </dependency>
+       <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-human-task-mapdb</artifactId>
+        <version>${version.org.kie}</version>
+       </dependency>
+       <dependency>
+         <groupId>org.jbpm</groupId>
+         <artifactId>jbpm-human-task-mapdb</artifactId>
          <version>${version.org.kie}</version>
          <classifier>sources</classifier>
        </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,8 @@
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
     <version.org.kie.latestFinal.release>6.5.0.Final</version.org.kie.latestFinal.release>
 
+    <version.org.mapdb>3.0.2</version.org.mapdb>
+    <version.org.jetbrains.kotlin>1.0.2</version.org.jetbrains.kotlin>
     <!-- using undertow for kie server router - same version as it comes with WildFly 10.0.0.Final-->
     <version.io.undertow.core>1.3.15.Final</version.io.undertow.core>
 
@@ -1947,6 +1949,16 @@
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>${version.commons-beanutils}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mapdb</groupId>
+        <artifactId>mapdb</artifactId>
+        <version>${version.org.mapdb}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-runtime</artifactId>
+        <version>${version.org.jetbrains.kotlin}</version>
       </dependency>
       <dependency>
         <groupId>com.spotify</groupId>


### PR DESCRIPTION
Implementation of MapDB persistence layer for Drools and jBPM persistence. This requires a set of modifications:
 - Creating drools-persistence-api and jbpm-persistence-api
 - SingleSessionCommandService refactors
 - PersistenceContext and ProcessPersistenceContext refactors:
 - TaskPersistenceContext refactors
 - Changes in the current persistence model interfaces
 - TimerJobFactoryManager / TimerService refactors