### PR TITLE
JBPM-5389: Added Stunner SVG support modules.

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -1577,6 +1577,32 @@
         <classifier>sources</classifier>
       </dependency>
 
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-svg-gen</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-svg-gen</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-svg-client</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-svg-client</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <!-- Stunner - Backend -->
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
     <version.org.hibernate.hibernate-validator>4.1.0.Final</version.org.hibernate.hibernate-validator>
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
+    <!-- CSS parsing library from Apache used by Stunner. -->
+    <version.net.sourceforge.cssparser>0.9.21</version.net.sourceforge.cssparser>
+    <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
+
     <!-- In community builds productized is false, in product builds it's true to enable branding changes -->
     <org.kie.productized>false</org.kie.productized>
 
@@ -1992,6 +1996,19 @@
         <artifactId>resteasy-jackson2-provider</artifactId>
         <version>${version.org.jboss.resteasy}</version>
       </dependency>
+
+      <!-- CSS parsing library from Apache used by Stunner. -->
+      <dependency>
+        <groupId>net.sourceforge.cssparser</groupId>
+        <artifactId>cssparser</artifactId>
+        <version>${version.net.sourceforge.cssparser}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.w3c.css</groupId>
+        <artifactId>sac</artifactId>
+        <version>${version.org.w3c.css.sac}</version>
+      </dependency>
+
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
Added Stunner's SVG support modules and their transitive dependencies.
See [this Jira ticket](https://issues.jboss.org/browse/JBPM-5389)